### PR TITLE
Module support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,8 @@
 
 # linkeR v0.1.1
 
-==============
-
-## New Features
-
 * Adds support for modular shiny applications
-
-==============
 
 # linkeR v0.1.0
 
-==============
-
 * Pre-CRAN submission
-
-==============

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
-# linkeR 0.1.0
+
+# linkeR v0.1.1
+
+==============
+
+## New Features
+
+* Adds support for modular shiny applications
+
+==============
+
+# linkeR v0.1.0
+
+==============
 
 * Pre-CRAN submission
+
+==============

--- a/R/dt.R
+++ b/R/dt.R
@@ -2,7 +2,7 @@
 #'
 #' `register_dt` registers a DT datatable for linking with other components.
 #'
-#' @param module_session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
+#' @param session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
 #' @param registry A link registry created by \code{create_link_registry()}
 #' @param dt_output_id Character string: the outputId of your DT::DTOutput
 #' @param data_reactive Reactive expression returning the data frame for the table
@@ -28,12 +28,12 @@
 #'   })
 #'
 #'   # Register a DT component
-#'   register_dt(registry, "my_table", my_data, "id")
+#'   register_dt(session, registry, "my_table", my_data, "id")
 #'
 #'   # Verify registration
 #'   print(registry$get_components())
 #' }
-register_dt <- function(module_session, registry, dt_output_id, data_reactive, shared_id_column,
+register_dt <- function(session, registry, dt_output_id, data_reactive, shared_id_column,
                         click_handler = NULL) {
   # Check if DT is available
   if (!requireNamespace("DT", quietly = TRUE)) {
@@ -54,7 +54,7 @@ register_dt <- function(module_session, registry, dt_output_id, data_reactive, s
 
   # Register with the registry
   registry$register_component(
-    module_session = module_session,
+    session = session,
     component_id = dt_output_id,
     type = "datatable",
     data_reactive = data_reactive,

--- a/R/dt.R
+++ b/R/dt.R
@@ -2,6 +2,7 @@
 #'
 #' `register_dt` registers a DT datatable for linking with other components.
 #'
+#' @param module_session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
 #' @param registry A link registry created by \code{create_link_registry()}
 #' @param dt_output_id Character string: the outputId of your DT::DTOutput
 #' @param data_reactive Reactive expression returning the data frame for the table
@@ -32,7 +33,7 @@
 #'   # Verify registration
 #'   print(registry$get_components())
 #' }
-register_dt <- function(registry, dt_output_id, data_reactive, shared_id_column,
+register_dt <- function(module_session, registry, dt_output_id, data_reactive, shared_id_column,
                         click_handler = NULL) {
   # Check if DT is available
   if (!requireNamespace("DT", quietly = TRUE)) {
@@ -53,6 +54,7 @@ register_dt <- function(registry, dt_output_id, data_reactive, shared_id_column,
 
   # Register with the registry
   registry$register_component(
+    module_session = module_session,
     component_id = dt_output_id,
     type = "datatable",
     data_reactive = data_reactive,

--- a/R/dt.R
+++ b/R/dt.R
@@ -3,8 +3,8 @@
 #' `register_dt` registers a DT datatable for linking with other components.
 #'
 #' @param session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
-#' @param registry A link registry created by \code{create_link_registry()}
-#' @param dt_output_id Character string: the outputId of your DT::DTOutput
+#' @param registry A link registry created by [create_link_registry()]
+#' @param dt_output_id Character string: the outputId of your [DT::DTOutput]
 #' @param data_reactive Reactive expression returning the data frame for the table
 #' @param shared_id_column Character string: name of the ID column
 #' @param click_handler Optional function: custom click handler for row selection

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -3,7 +3,7 @@
 #' `register_leaflet` registers a Leaflet map for linking with other components.
 #'
 #' @param session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
-#' @param registry A link registry created by \code{create_link_registry()}
+#' @param registry A link registry created by [create_link_registry()]
 #' @param leaflet_output_id Character string: the outputId of your leafletOutput
 #' @param data_reactive Reactive expression returning the data frame for the map
 #' @param shared_id_column Character string: name of the ID column

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -2,6 +2,7 @@
 #'
 #' `register_leaflet` registers a Leaflet map for linking with other components.
 #'
+#' @param module_session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
 #' @param registry A link registry created by \code{create_link_registry()}
 #' @param leaflet_output_id Character string: the outputId of your leafletOutput
 #' @param data_reactive Reactive expression returning the data frame for the map
@@ -35,7 +36,7 @@
 #'   # Verify registration
 #'   print(registry$get_components())
 #' }
-register_leaflet <- function(registry, leaflet_output_id, data_reactive,
+register_leaflet <- function(module_session, registry, leaflet_output_id, data_reactive,
                              shared_id_column, lng_col = "longitude",
                              lat_col = "latitude", highlight_zoom = 12,
                              click_handler = NULL) {
@@ -79,6 +80,7 @@ register_leaflet <- function(registry, leaflet_output_id, data_reactive,
 
   # Register with the registry using processed data
   registry$register_component(
+    module_session = module_session,
     component_id = leaflet_output_id,
     type = "leaflet",
     data_reactive = processed_data_reactive,

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -2,7 +2,7 @@
 #'
 #' `register_leaflet` registers a Leaflet map for linking with other components.
 #'
-#' @param module_session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
+#' @param session Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.
 #' @param registry A link registry created by \code{create_link_registry()}
 #' @param leaflet_output_id Character string: the outputId of your leafletOutput
 #' @param data_reactive Reactive expression returning the data frame for the map
@@ -36,7 +36,7 @@
 #'   # Verify registration
 #'   print(registry$get_components())
 #' }
-register_leaflet <- function(module_session, registry, leaflet_output_id, data_reactive,
+register_leaflet <- function(session, registry, leaflet_output_id, data_reactive,
                              shared_id_column, lng_col = "longitude",
                              lat_col = "latitude", highlight_zoom = 12,
                              click_handler = NULL) {
@@ -80,7 +80,7 @@ register_leaflet <- function(module_session, registry, leaflet_output_id, data_r
 
   # Register with the registry using processed data
   registry$register_component(
-    module_session = module_session,
+    session = session,
     component_id = leaflet_output_id,
     type = "leaflet",
     data_reactive = processed_data_reactive,

--- a/R/registry.R
+++ b/R/registry.R
@@ -11,9 +11,10 @@
 #'
 #' @return A link_registry object with the following methods:
 #' \describe{
-#'   \item{register_component(component_id, type, data_reactive, shared_id_column, config)}{
+#'   \item{register_component(module_session, component_id, type, data_reactive, shared_id_column, config)}{
 #'     Register a new component with the registry. Parameters:
 #'     \itemize{
+#'       \item module_session: Shiny session object for namespacing. Can be global session in non-modular apps.
 #'       \item component_id: Unique string identifier for the component
 #'       \item type: Component type (e.g., "table", "plot")
 #'       \item data_reactive: Reactive expression returning the component's data
@@ -71,7 +72,7 @@ create_link_registry <- function(session, on_selection_change = NULL) {
   # Registry methods
   registry <- list(
     # Register a new component
-    register_component = function(component_id, type, data_reactive,
+    register_component = function(module_session, component_id, type, data_reactive,
                                   shared_id_column, config = list()) {
       # Validation
       if (!is.character(component_id) || length(component_id) != 1) {
@@ -84,9 +85,12 @@ create_link_registry <- function(session, on_selection_change = NULL) {
         stop("shared_id_column must be a string")
       }
 
+      # get the namespaced id if module_session is provided
+      namespaced_id <- module_session$ns(component_id)
+
       # Destroy existing observers for this component if they exist
-      if (component_id %in% names(observers)) {
-        for (obs in observers[[component_id]]) {
+      if (namespaced_id %in% names(observers)) {
+        for (obs in observers[[namespaced_id]]) {
           if (!is.null(obs) && !is.null(obs$destroy)) {
             obs$destroy()
           }
@@ -94,7 +98,7 @@ create_link_registry <- function(session, on_selection_change = NULL) {
       }
 
       # Store component information
-      components[[component_id]] <<- list(
+      components[[namespaced_id]] <<- list(
         type = type,
         data_reactive = data_reactive,
         shared_id_column = shared_id_column,
@@ -102,8 +106,8 @@ create_link_registry <- function(session, on_selection_change = NULL) {
       )
 
       # Set up component-specific observers and store them
-      observers[[component_id]] <<- setup_component_observers(
-        component_id, type, session, components, shared_state, on_selection_change,
+      observers[[namespaced_id]] <<- setup_component_observers(
+        namespaced_id, type, session, components, shared_state, on_selection_change,
         registry = list(set_selection = registry$set_selection)
       )
 

--- a/R/registry.R
+++ b/R/registry.R
@@ -57,7 +57,7 @@
 #' registry$register_component("plot1", "plot", reactive(my_data), "id")
 #' }
 #'
-#' @seealso \code{\link{setup_component_observers}} for component observer setup
+#' @seealso [setup_component_observers()] for component observer setup
 create_link_registry <- function(session, on_selection_change = NULL) {
   # Validate inputs
   if (missing(session)) {

--- a/R/registry.R
+++ b/R/registry.R
@@ -161,7 +161,7 @@ create_link_registry <- function(session, on_selection_change = NULL) {
 
         tryCatch(
           {
-            on_selection_change(selected_id, selected_data, source_component_id, session)
+            on_selection_change(selected_id, selected_data, source_component_id, top_level_session)
           },
           error = function(e) {
             warning("Error in on_selection_change callback: ", e$message)

--- a/R/simple_api.R
+++ b/R/simple_api.R
@@ -10,9 +10,9 @@
 #' for straightforward dashboards.
 #'
 #' For more complex applications that use **Shiny Modules**, you should use the
-#' more robust pattern of creating a central registry with `create_link_registry()`
-#' and passing it to your modules, where you will call `register_leaflet()` or
-#' `register_dt()` directly. This preserves module encapsulation and leads to
+#' more robust pattern of creating a central registry with [create_link_registry()]
+#' and passing it to your modules, where you will call [register_leaflet()] or
+#' [register_dt()] directly. This preserves module encapsulation and leads to
 #' more maintainable code. See the `modularized_example` for a complete example of this pattern.
 #'
 #' @param session The Shiny session object

--- a/R/simple_api.R
+++ b/R/simple_api.R
@@ -144,6 +144,7 @@ link_plots <- function(session, ..., shared_id_column,
 
       # USE REGISTER_LEAFLET FUNCTION
       register_leaflet(
+        session = session,  # this is just the global session in the case of single file applications
         registry = registry,
         leaflet_output_id = comp_name,
         data_reactive = comp_data,
@@ -151,8 +152,7 @@ link_plots <- function(session, ..., shared_id_column,
         lng_col = leaflet_lng_col,
         lat_col = leaflet_lat_col,
         highlight_zoom = 12,
-        click_handler = leaflet_click_handler,
-        session = session  # this is just the global session in the case of single file applications
+        click_handler = leaflet_click_handler
       )
       
     } else if (comp_type == "datatable") {
@@ -166,12 +166,12 @@ link_plots <- function(session, ..., shared_id_column,
 
       # USE REGISTER_DT FUNCTION
       register_dt(
+        session = session,  # this is just the global session in the case of single file applications
         registry = registry,
         dt_output_id = comp_name,
         data_reactive = comp_data,
         shared_id_column = shared_id_column,
-        click_handler = dt_click_handler,
-        session = session  # this is just the global session in the case of single file applications
+        click_handler = dt_click_handler
       )
     }
   }

--- a/R/simple_api.R
+++ b/R/simple_api.R
@@ -139,7 +139,8 @@ link_plots <- function(session, ..., shared_id_column,
         lng_col = leaflet_lng_col,
         lat_col = leaflet_lat_col,
         highlight_zoom = 12,
-        click_handler = leaflet_click_handler
+        click_handler = leaflet_click_handler,
+        module_session = session  # this is just the global session in the case of single file applications
       )
       
     } else if (comp_type == "datatable") {
@@ -157,7 +158,8 @@ link_plots <- function(session, ..., shared_id_column,
         dt_output_id = comp_name,
         data_reactive = comp_data,
         shared_id_column = shared_id_column,
-        click_handler = dt_click_handler
+        click_handler = dt_click_handler,
+        module_session = session  # this is just the global session in the case of single file applications
       )
     }
   }

--- a/R/simple_api.R
+++ b/R/simple_api.R
@@ -152,7 +152,7 @@ link_plots <- function(session, ..., shared_id_column,
         lat_col = leaflet_lat_col,
         highlight_zoom = 12,
         click_handler = leaflet_click_handler,
-        module_session = session  # this is just the global session in the case of single file applications
+        session = session  # this is just the global session in the case of single file applications
       )
       
     } else if (comp_type == "datatable") {
@@ -171,7 +171,7 @@ link_plots <- function(session, ..., shared_id_column,
         data_reactive = comp_data,
         shared_id_column = shared_id_column,
         click_handler = dt_click_handler,
-        module_session = session  # this is just the global session in the case of single file applications
+        session = session  # this is just the global session in the case of single file applications
       )
     }
   }

--- a/R/simple_api.R
+++ b/R/simple_api.R
@@ -1,9 +1,19 @@
-#' Simple Plot Linking Function
+#' Simple Plot Linking Function for Non-Modular Shiny Apps
 #'
-#' `link_plots` is a simple interface to link interactive plots and tables in Shiny.
-#' This function automatically detects component types and sets up bidirectional linking.
-#' For more robust applications, especially with complex naming schemes, consider using
-#' \code{\link{register_leaflet}} and \code{\link{register_dt}} directly.
+#' @description
+#' `link_plots` provides a simple, one-line interface to link interactive
+#' components in a **single-file or non-modular Shiny application**. It
+#' automatically detects component types and sets up bidirectional linking.
+#'
+#' @details
+#' This function is the fastest way to get started with `linkeR` and is ideal
+#' for straightforward dashboards.
+#'
+#' For more complex applications that use **Shiny Modules**, you should use the
+#' more robust pattern of creating a central registry with `create_link_registry()`
+#' and passing it to your modules, where you will call `register_leaflet()` or
+#' `register_dt()` directly. This preserves module encapsulation and leads to
+#' more maintainable code. See the `modularized_example` for a complete example of this pattern.
 #'
 #' @param session The Shiny session object
 #' @param ... Named arguments where names are component output IDs and values are
@@ -27,6 +37,8 @@
 #' @return Invisibly returns the created registry object
 #' @export
 #' @examples
+#' # This example is for a single-file app.
+#' # For modular apps, please see the "Using linkeR with Modules" vignette.
 #' if (interactive()) {
 #'   library(shiny)
 #'   library(leaflet)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -53,6 +53,11 @@ articles:
   contents:
   - getting-started
 
+- title: "Using with Shiny Modules"
+  navbar: ~
+  contents:
+  - using-with-modules
+
 - title: "Advanced Usage"
   navbar: ~
   contents:

--- a/inst/examples/modularized_example/app.R
+++ b/inst/examples/modularized_example/app.R
@@ -97,8 +97,12 @@ server <- function(input, output, session) {
     generate_wastewater_data()
   })
   
+  on_selection_change <- function(selected_id, selected_data, source, session) {
+    message("Selection changed to ID: ", selected_id, " from: ", source)
+  }
+
   # Create the link registry
-  registry <- create_link_registry(session)
+  registry <- create_link_registry(session, on_selection_change = on_selection_change)
 
   # Call module servers
   mapServer("map_module", wastewater_data, registry)

--- a/inst/examples/modularized_example/app.R
+++ b/inst/examples/modularized_example/app.R
@@ -1,0 +1,153 @@
+library(shiny)
+library(leaflet)
+library(DT)
+library(linkeR)
+library(bslib)
+
+# Source the modules
+source("map_module.R")
+source("table_module.R")
+
+# --- Data Generation (copied from basic_app.R) ---
+# Generate realistic wastewater monitoring data for Utah locations
+generate_wastewater_data <- function() {
+  # Real Utah city coordinates
+  utah_locations <- data.frame(
+    city = c("Salt Lake City", "Ogden", "Provo", "West Valley City", "Sandy", 
+             "Orem", "West Jordan", "Layton", "Taylorsville", "Murray"),
+    latitude = c(40.7608, 41.2230, 40.2338, 40.6916, 40.5649, 
+                40.2969, 40.6097, 41.0602, 40.6677, 40.6669),
+    longitude = c(-111.8910, -111.9738, -111.6585, -111.9391, -111.8389,
+                 -111.6946, -111.9391, -111.9710, -111.9391, -111.8879),
+    stringsAsFactors = FALSE
+  )
+  
+  n_sites <- nrow(utah_locations)
+  
+  # Generate realistic wastewater monitoring data
+  wastewater_data <- data.frame(
+    id = paste0("WW_", sprintf("%03d", 1:n_sites)),
+    facility_name = paste(utah_locations$city, "WWTP"),
+    city = utah_locations$city,
+    latitude = utah_locations$latitude,
+    longitude = utah_locations$longitude,
+    
+    # Monitoring parameters
+    covid_copies_per_ml = round(10^runif(n_sites, 2, 5.5)), # 100 to ~300,000
+    flow_mgd = round(runif(n_sites, 0.5, 45), 1), # Million gallons per day
+    population_served = round(runif(n_sites, 5000, 200000), -3),
+    
+    # Status based on COVID levels
+    risk_level = factor(
+      ifelse(10^runif(n_sites, 2, 5.5) > 10000, "High",
+             ifelse(10^runif(n_sites, 2, 5.5) > 1000, "Medium", "Low")),
+      levels = c("Low", "Medium", "High")
+    ),
+    
+    # Sample timing
+    last_sample_date = Sys.Date() - sample(0:7, n_sites, replace = TRUE),
+    next_sample_date = Sys.Date() + sample(1:7, n_sites, replace = TRUE),
+    
+    # Additional parameters
+    ph = round(runif(n_sites, 6.5, 8.5), 1),
+    temperature_f = round(runif(n_sites, 45, 75), 1),
+    
+    stringsAsFactors = FALSE
+  )
+  
+  return(wastewater_data)
+}
+
+# --- UI ---
+ui <- fluidPage(
+  theme = bs_theme(version = 5, bootswatch = "cerulean"),
+  titlePanel("linkeR Module Linking Demonstration"),
+  
+  layout_sidebar(
+    sidebar = sidebar(
+      title = "Dashboard Controls",
+      p("This example demonstrates the issue of using linkeR across Shiny modules. 
+         The linking is expected to fail because the component IDs are namespaced."),
+      hr(),
+      verbatimTextOutput("selection_info", placeholder = TRUE)
+    ),
+    
+    div(
+      fluidRow(
+        column(7,
+          h4("Wastewater Map (Module 1)"),
+          # Call the map module UI
+          mapUI("map_module")
+        ),
+        column(5,
+          h4("Facility Data (Module 2)"),
+          # Call the table module UI
+          tableUI("table_module")
+        )
+      )
+    )
+  )
+)
+
+# --- Server ---
+server <- function(input, output, session) {
+  
+  # Reactive data
+  wastewater_data <- reactive({
+    generate_wastewater_data()
+  })
+  
+  # Store registry in reactiveVal to manage it properly
+  current_registry <- reactiveVal(NULL)
+
+  # Call module servers
+  mapServer("map_module", wastewater_data)
+  tableServer("table_module", wastewater_data)
+  
+  # print columns of wastewater_data
+  observe({
+    print(colnames(wastewater_data()))
+  })
+
+  observeEvent(session$clientData, {
+      registry <- link_plots(
+        session,
+        shared_id_column = "id",
+        map_module_wastewater_map = wastewater_data,
+        table_module_wastewater_table = wastewater_data,
+        leaflet_click_handler = function(input, output, session, id) {
+          # Handle leaflet click events
+          selected_id <- input$map_module_wastewater_map_marker_click$id
+          print(paste("Selected ID from map:", selected_id))
+          if (!is.null(selected_id)) {
+            # Update the selection in the registry
+            registry$set_selection(selected_id, "map_module")
+          }
+        },
+        on_selection_change = function(selected_id, source) {
+          print(paste("Selection changed to ID:", selected_id, "from source:", source))
+        }
+      )
+
+      current_registry(registry)
+  }, once = TRUE)
+
+  
+  # Selection info display
+  output$selection_info <- renderText({
+    registry <- current_registry()
+    if (!is.null(registry)) {
+      selection <- registry$get_selection()
+      if (!is.null(selection$selected_id)) {
+        paste("Selected ID:", selection$selected_id, "\nSource:", selection$source)
+      } else {
+        "No facility selected"
+      }
+    } else {
+      "Registry not initialized"
+    }
+  })
+}
+
+# Run the app
+shinyApp(ui, server)

--- a/inst/examples/modularized_example/map_module.R
+++ b/inst/examples/modularized_example/map_module.R
@@ -13,8 +13,18 @@ mapUI <- function(id) {
 #'
 #' @param id A character string. The namespace ID.
 #' @param data A reactive expression returning the data frame for the map.
-mapServer <- function(id, data) {
+#' @param registry A link_registry object for managing component linking.
+mapServer <- function(id, data, registry) {
   moduleServer(id, function(input, output, session) {
+    # Register this component with the central registry
+    register_leaflet(
+      module_session = session, # <-- pass the module's session
+      registry = registry,
+      leaflet_output_id = "wastewater_map", # <-- the local ID
+      data_reactive = data,
+      shared_id_column = "id"
+    )
+
     output$wastewater_map <- renderLeaflet({
       map_data <- data()
       

--- a/inst/examples/modularized_example/map_module.R
+++ b/inst/examples/modularized_example/map_module.R
@@ -18,7 +18,7 @@ mapServer <- function(id, data, registry) {
   moduleServer(id, function(input, output, session) {
     # Register this component with the central registry
     register_leaflet(
-      module_session = session, # <-- pass the module's session
+      session = session, # <-- pass the module's session
       registry = registry,
       leaflet_output_id = "wastewater_map", # <-- the local ID
       data_reactive = data,

--- a/inst/examples/modularized_example/map_module.R
+++ b/inst/examples/modularized_example/map_module.R
@@ -1,0 +1,40 @@
+# /path/to/your/app/map_module.R
+
+#' Map Module UI
+#'
+#' @param id A character string. The namespace ID.
+#' @return A UI definition.
+mapUI <- function(id) {
+  ns <- NS(id)
+  leafletOutput(ns("wastewater_map"), height = "500px")
+}
+
+#' Map Module Server
+#'
+#' @param id A character string. The namespace ID.
+#' @param data A reactive expression returning the data frame for the map.
+mapServer <- function(id, data) {
+  moduleServer(id, function(input, output, session) {
+    output$wastewater_map <- renderLeaflet({
+      map_data <- data()
+      
+      # Color palette for risk levels
+      risk_colors <- c("Low" = "green", "Medium" = "orange", "High" = "red")
+      
+      leaflet(map_data) %>%
+        addTiles() %>%
+        addCircleMarkers(
+          lng = ~longitude,
+          lat = ~latitude,
+          layerId = ~id, # Critical for linking!
+          radius = ~sqrt(flow_mgd) * 2 + 5,
+          color = ~risk_colors[risk_level],
+          fillColor = ~risk_colors[risk_level],
+          fillOpacity = 0.7,
+          stroke = TRUE,
+          weight = 2
+        ) %>%
+        setView(lng = -111.8910, lat = 40.7608, zoom = 8) # Centered on Utah
+    })
+  })
+}

--- a/inst/examples/modularized_example/table_module.R
+++ b/inst/examples/modularized_example/table_module.R
@@ -1,0 +1,42 @@
+# /path/to/your/app/table_module.R
+
+#' Table Module UI
+#'
+#' @param id A character string. The namespace ID.
+#' @return A UI definition.
+tableUI <- function(id) {
+  ns <- NS(id)
+  DTOutput(ns("wastewater_table"))
+}
+
+#' Table Module Server
+#'
+#' @param id A character string. The namespace ID.
+#' @param data A reactive expression returning the data frame for the table.
+tableServer <- function(id, data) {
+  moduleServer(id, function(input, output, session) {
+    output$wastewater_table <- renderDT({
+      table_data <- data()[, c("facility_name", "city", "risk_level", 
+                               "covid_copies_per_ml", "population_served", 
+                               "last_sample_date")]
+      
+      datatable(
+        table_data,
+        selection = "single",
+        rownames = FALSE,
+        colnames = c("Facility", "City", "Risk", "COVID Copies/mL", 
+                     "Population", "Last Sample"),
+        options = list(
+          pageLength = 8,
+          scrollX = TRUE,
+          order = list(list(3, 'desc'))
+        )
+      ) %>%
+        formatCurrency(c("covid_copies_per_ml", "population_served"), currency = "", digits = 0) %>%
+        formatStyle("risk_level",
+                    backgroundColor = styleEqual(c("Low", "Medium", "High"), 
+                                                 c("lightgreen", "orange", "lightcoral"))
+        )
+    })
+  })
+}

--- a/inst/examples/modularized_example/table_module.R
+++ b/inst/examples/modularized_example/table_module.R
@@ -13,8 +13,18 @@ tableUI <- function(id) {
 #'
 #' @param id A character string. The namespace ID.
 #' @param data A reactive expression returning the data frame for the table.
-tableServer <- function(id, data) {
+#' @param registry A link_registry object for managing component linking.
+tableServer <- function(id, data, registry) {
   moduleServer(id, function(input, output, session) {
+    # Register this component with the central registry
+    register_dt(
+      module_session = session, # <-- pass the module's session
+      registry = registry,
+      dt_output_id = "wastewater_table", # <-- the local ID
+      data_reactive = data,
+      shared_id_column = "id"
+    )
+
     output$wastewater_table <- renderDT({
       table_data <- data()[, c("facility_name", "city", "risk_level", 
                                "covid_copies_per_ml", "population_served", 

--- a/inst/examples/modularized_example/table_module.R
+++ b/inst/examples/modularized_example/table_module.R
@@ -18,7 +18,7 @@ tableServer <- function(id, data, registry) {
   moduleServer(id, function(input, output, session) {
     # Register this component with the central registry
     register_dt(
-      module_session = session, # <-- pass the module's session
+      session = session, # <-- pass the module's session
       registry = registry,
       dt_output_id = "wastewater_table", # <-- the local ID
       data_reactive = data,

--- a/man/create_link_registry.Rd
+++ b/man/create_link_registry.Rd
@@ -68,5 +68,5 @@ registry$register_component("plot1", "plot", reactive(my_data), "id")
 
 }
 \seealso{
-\code{\link{setup_component_observers}} for component observer setup
+\code{\link[=setup_component_observers]{setup_component_observers()}} for component observer setup
 }

--- a/man/create_link_registry.Rd
+++ b/man/create_link_registry.Rd
@@ -16,9 +16,10 @@ source_component_id, and session}
 \value{
 A link_registry object with the following methods:
 \describe{
-\item{register_component(component_id, type, data_reactive, shared_id_column, config)}{
+\item{register_component(module_session, component_id, type, data_reactive, shared_id_column, config)}{
 Register a new component with the registry. Parameters:
 \itemize{
+\item module_session: Shiny session object for namespacing. Can be global session in non-modular apps.
 \item component_id: Unique string identifier for the component
 \item type: Component type (e.g., "table", "plot")
 \item data_reactive: Reactive expression returning the component's data

--- a/man/create_link_registry.Rd
+++ b/man/create_link_registry.Rd
@@ -16,10 +16,10 @@ source_component_id, and session}
 \value{
 A link_registry object with the following methods:
 \describe{
-\item{register_component(module_session, component_id, type, data_reactive, shared_id_column, config)}{
+\item{register_component(session, component_id, type, data_reactive, shared_id_column, config)}{
 Register a new component with the registry. Parameters:
 \itemize{
-\item module_session: Shiny session object for namespacing. Can be global session in non-modular apps.
+\item session: Shiny session object for namespacing. Can be global session in non-modular apps.
 \item component_id: Unique string identifier for the component
 \item type: Component type (e.g., "table", "plot")
 \item data_reactive: Reactive expression returning the component's data

--- a/man/link_plots.Rd
+++ b/man/link_plots.Rd
@@ -56,9 +56,9 @@ This function is the fastest way to get started with \code{linkeR} and is ideal
 for straightforward dashboards.
 
 For more complex applications that use \strong{Shiny Modules}, you should use the
-more robust pattern of creating a central registry with \code{create_link_registry()}
-and passing it to your modules, where you will call \code{register_leaflet()} or
-\code{register_dt()} directly. This preserves module encapsulation and leads to
+more robust pattern of creating a central registry with \code{\link[=create_link_registry]{create_link_registry()}}
+and passing it to your modules, where you will call \code{\link[=register_leaflet]{register_leaflet()}} or
+\code{\link[=register_dt]{register_dt()}} directly. This preserves module encapsulation and leads to
 more maintainable code. See the \code{modularized_example} for a complete example of this pattern.
 }
 \examples{

--- a/man/link_plots.Rd
+++ b/man/link_plots.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/simple_api.R
 \name{link_plots}
 \alias{link_plots}
-\title{Simple Plot Linking Function}
+\title{Simple Plot Linking Function for Non-Modular Shiny Apps}
 \usage{
 link_plots(
   session,
@@ -47,12 +47,23 @@ Function should accept parameters: (selected_id, selected_data, source_component
 Invisibly returns the created registry object
 }
 \description{
-\code{link_plots} is a simple interface to link interactive plots and tables in Shiny.
-This function automatically detects component types and sets up bidirectional linking.
-For more robust applications, especially with complex naming schemes, consider using
-\code{\link{register_leaflet}} and \code{\link{register_dt}} directly.
+\code{link_plots} provides a simple, one-line interface to link interactive
+components in a \strong{single-file or non-modular Shiny application}. It
+automatically detects component types and sets up bidirectional linking.
+}
+\details{
+This function is the fastest way to get started with \code{linkeR} and is ideal
+for straightforward dashboards.
+
+For more complex applications that use \strong{Shiny Modules}, you should use the
+more robust pattern of creating a central registry with \code{create_link_registry()}
+and passing it to your modules, where you will call \code{register_leaflet()} or
+\code{register_dt()} directly. This preserves module encapsulation and leads to
+more maintainable code. See the \code{modularized_example} for a complete example of this pattern.
 }
 \examples{
+# This example is for a single-file app.
+# For modular apps, please see the "Using linkeR with Modules" vignette.
 if (interactive()) {
   library(shiny)
   library(leaflet)

--- a/man/register_dt.Rd
+++ b/man/register_dt.Rd
@@ -5,6 +5,7 @@
 \title{Register a DT DataTable Component}
 \usage{
 register_dt(
+  module_session,
   registry,
   dt_output_id,
   data_reactive,
@@ -13,6 +14,8 @@ register_dt(
 )
 }
 \arguments{
+\item{module_session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
+
 \item{registry}{A link registry created by \code{create_link_registry()}}
 
 \item{dt_output_id}{Character string: the outputId of your DT::DTOutput}

--- a/man/register_dt.Rd
+++ b/man/register_dt.Rd
@@ -5,7 +5,7 @@
 \title{Register a DT DataTable Component}
 \usage{
 register_dt(
-  module_session,
+  session,
   registry,
   dt_output_id,
   data_reactive,
@@ -14,7 +14,7 @@ register_dt(
 )
 }
 \arguments{
-\item{module_session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
+\item{session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
 
 \item{registry}{A link registry created by \code{create_link_registry()}}
 
@@ -50,7 +50,7 @@ NULL (invisible). This function is called for its side effects of registering th
   })
 
   # Register a DT component
-  register_dt(registry, "my_table", my_data, "id")
+  register_dt(session, registry, "my_table", my_data, "id")
 
   # Verify registration
   print(registry$get_components())

--- a/man/register_dt.Rd
+++ b/man/register_dt.Rd
@@ -16,9 +16,9 @@ register_dt(
 \arguments{
 \item{session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
 
-\item{registry}{A link registry created by \code{create_link_registry()}}
+\item{registry}{A link registry created by \code{\link[=create_link_registry]{create_link_registry()}}}
 
-\item{dt_output_id}{Character string: the outputId of your DT::DTOutput}
+\item{dt_output_id}{Character string: the outputId of your \link[DT:dataTableOutput]{DT::DTOutput}}
 
 \item{data_reactive}{Reactive expression returning the data frame for the table}
 

--- a/man/register_leaflet.Rd
+++ b/man/register_leaflet.Rd
@@ -5,7 +5,7 @@
 \title{Register a Leaflet Component}
 \usage{
 register_leaflet(
-  module_session,
+  session,
   registry,
   leaflet_output_id,
   data_reactive,
@@ -17,7 +17,7 @@ register_leaflet(
 )
 }
 \arguments{
-\item{module_session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
+\item{session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
 
 \item{registry}{A link registry created by \code{create_link_registry()}}
 

--- a/man/register_leaflet.Rd
+++ b/man/register_leaflet.Rd
@@ -19,7 +19,7 @@ register_leaflet(
 \arguments{
 \item{session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
 
-\item{registry}{A link registry created by \code{create_link_registry()}}
+\item{registry}{A link registry created by \code{\link[=create_link_registry]{create_link_registry()}}}
 
 \item{leaflet_output_id}{Character string: the outputId of your leafletOutput}
 

--- a/man/register_leaflet.Rd
+++ b/man/register_leaflet.Rd
@@ -5,6 +5,7 @@
 \title{Register a Leaflet Component}
 \usage{
 register_leaflet(
+  module_session,
   registry,
   leaflet_output_id,
   data_reactive,
@@ -16,6 +17,8 @@ register_leaflet(
 )
 }
 \arguments{
+\item{module_session}{Shiny session object. The session from the module where the DT is used. This could be global session in non-modular apps.}
+
 \item{registry}{A link registry created by \code{create_link_registry()}}
 
 \item{leaflet_output_id}{Character string: the outputId of your leafletOutput}

--- a/tests/testthat/test-modular.R
+++ b/tests/testthat/test-modular.R
@@ -1,0 +1,317 @@
+test_that("registry handles multiple sessions correctly", {
+  skip_if_not_installed("DT")
+  skip_if_not_installed("leaflet")
+  
+  # Create separate sessions (simulating different modules)
+  main_session <- shiny::MockShinySession$new()
+  map_session <- main_session$makeScope("map-module")
+  table_session <- main_session$makeScope("table-module")
+  
+  # Create shared registry (in real apps, this would be passed between modules)
+  registry <- create_link_registry(main_session)
+  
+  # Create test data
+  locations_data <- reactive({
+    data.frame(
+      facility_id = c("FAC_001", "FAC_002", "FAC_003"),
+      name = c("Facility A", "Facility B", "Facility C"),
+      latitude = c(40.7128, 41.8781, 42.3601),
+      longitude = c(-74.0060, -87.6298, -71.0589)
+    )
+  })
+  
+  facilities_data <- reactive({
+    data.frame(
+      facility_id = c("FAC_001", "FAC_002", "FAC_003"),
+      name = c("Facility A", "Facility B", "Facility C"),
+      status = c("Active", "Maintenance", "Active"),
+      capacity = c(1000, 1500, 800)
+    )
+  })
+  
+  # Register components from different sessions (simulating modules)
+  expect_no_error({
+    register_leaflet(
+      session = map_session,
+      registry = registry,
+      leaflet_output_id = "facility_map",
+      data_reactive = locations_data,
+      shared_id_column = "facility_id"
+    )
+  })
+  
+  expect_no_error({
+    register_dt(
+      session = table_session,
+      registry = registry,
+      dt_output_id = "facility_table", 
+      data_reactive = facilities_data,
+      shared_id_column = "facility_id"
+    )
+  })
+  
+  # Verify both components are registered
+  components <- registry$get_components()
+  expect_length(components, 2)
+  
+  # Check that component names are properly stored
+  component_names <- names(components)
+  expect_true(any(grepl(map_session$ns("facility_map"), component_names)))
+  expect_true(any(grepl(table_session$ns("facility_table"), component_names)))
+})
+
+test_that("cross-session selection works correctly", {
+  skip_if_not_installed("DT")
+  skip_if_not_installed("leaflet")
+  
+  # Setup separate sessions
+  main_session <- shiny::MockShinySession$new()
+  map_session <- main_session$makeScope("map-module")
+  table_session <- main_session$makeScope("table-module")
+  
+  # Track selection changes
+  selection_history <- list()
+  callback <- function(selected_id, selected_data, source_id, session) {
+    selection_history <<- append(selection_history, list(list(
+      selected_id = selected_id,
+      source_id = source_id
+    )))
+  }
+  
+  registry <- create_link_registry(main_session, on_selection_change = callback)
+  
+  # Test data
+  test_data <- reactive({
+    data.frame(
+      id = c("A", "B", "C"),
+      name = c("Item A", "Item B", "Item C"),
+      latitude = c(40, 41, 42),
+      longitude = c(-100, -101, -102)
+    )
+  })
+  
+  # Register components (simulating different modules)
+  register_leaflet(
+    session = map_session,
+    registry = registry,
+    leaflet_output_id = "map",
+    data_reactive = test_data,
+    shared_id_column = "id"
+  )
+  
+  register_dt(
+    session = table_session,
+    registry = registry,
+    dt_output_id = "table",
+    data_reactive = test_data,
+    shared_id_column = "id"
+  )
+  
+  # Simulate selection from map component
+  isolate({
+    registry$set_selection("B", "map")
+  })
+  
+  # Check selection was propagated
+  expect_length(selection_history, 1)
+  expect_equal(selection_history[[1]]$selected_id, "B")
+  expect_equal(selection_history[[1]]$source_id, "map")
+  
+  # Simulate selection from table component
+  isolate({
+    registry$set_selection("C", "table")
+  })
+  
+  expect_length(selection_history, 2)
+  expect_equal(selection_history[[2]]$selected_id, "C")
+  expect_equal(selection_history[[2]]$source_id, "table")
+})
+
+test_that("separate sessions maintain component isolation", {
+  skip_if_not_installed("DT")
+  
+  # Create separate sessions
+  session1 <- shiny::MockShinySession$new()
+  session2 <- shiny::MockShinySession$new()
+  
+  # Create separate registries (simulating different app instances)
+  registry1 <- create_link_registry(session1)
+  registry2 <- create_link_registry(session2)
+  
+  test_data <- reactive({
+    data.frame(
+      id = 1:3,
+      name = c("A", "B", "C"),
+      value = c(10, 20, 30)
+    )
+  })
+  
+  # Register same component name in different registries
+  register_dt(session1, registry1, "data_table", test_data, "id")
+  register_dt(session2, registry2, "data_table", test_data, "id")
+  
+  # Each registry should only have one component
+  components1 <- registry1$get_components()
+  components2 <- registry2$get_components()
+  
+  expect_length(components1, 1)
+  expect_length(components2, 1)
+  
+  # Selections should be isolated
+  isolate({
+    registry1$set_selection("1", "data_table")
+    registry2$set_selection("2", "data_table")
+  })
+  
+  selection1 <- isolate(registry1$get_selection())
+  selection2 <- isolate(registry2$get_selection())
+  
+  expect_equal(selection1$selected_id, "1")
+  expect_equal(selection2$selected_id, "2")
+})
+
+test_that("error handling in registration", {
+  skip_if_not_installed("DT")
+  
+  main_session <- shiny::MockShinySession$new()
+  
+  # Test with invalid registry
+  expect_error({
+    register_dt(
+      registry = NULL,
+      dt_output_id = "test_table",
+      data_reactive = reactive(data.frame(id = 1:2)),
+      shared_id_column = "id"
+    )
+  }, "registry")
+  
+  # Test with invalid reactive
+  registry <- create_link_registry(main_session)
+  
+  expect_error({
+    register_dt(
+      registry = registry,
+      dt_output_id = "test_table", 
+      data_reactive = data.frame(id = 1:2),  # Not reactive!
+      shared_id_column = "id"
+    )
+  }, "reactive")
+})
+
+test_that("custom handlers work in multi-component setup", {
+  skip_if_not_installed("DT")
+  skip_if_not_installed("leaflet")
+  
+  main_session <- shiny::MockShinySession$new()
+  map_session <- main_session$makeScope("map-module")
+  table_session <- main_session$makeScope("table-module")
+
+  registry <- create_link_registry(main_session)
+  
+  # Track custom handler calls
+  handler_calls <- list()
+  
+  custom_leaflet_handler <- function(map_proxy, selected_data, session) {
+    handler_calls <<- append(handler_calls, list(list(
+      type = "leaflet",
+      data = selected_data
+    )))
+  }
+  
+  custom_dt_handler <- function(dt_proxy, selected_data, session) {
+    handler_calls <<- append(handler_calls, list(list(
+      type = "dt", 
+      data = selected_data
+    )))
+  }
+  
+  test_data <- reactive({
+    data.frame(
+      id = c("ITEM_1", "ITEM_2"),
+      name = c("Item One", "Item Two"),
+      latitude = c(40.7, 40.8),
+      longitude = c(-74.0, -74.1)
+    )
+  })
+  
+  # Register with custom handlers
+  register_leaflet(
+    session = map_session,
+    registry = registry,
+    leaflet_output_id = "overview_map",
+    data_reactive = test_data,
+    shared_id_column = "id",
+    click_handler = custom_leaflet_handler
+  )
+  
+  register_dt(
+    session = table_session,
+    registry = registry,
+    dt_output_id = "detail_table",
+    data_reactive = test_data,
+    shared_id_column = "id",
+    click_handler = custom_dt_handler
+  )
+  
+  components <- registry$get_components()
+  expect_length(components, 2)
+  
+  # Verify custom handlers are stored
+  for (component in components) {
+    expect_true(is.function(component$config$click_handler))
+  }
+})
+
+test_that("registry state management across components", {
+  skip_if_not_installed("DT")
+  skip_if_not_installed("leaflet")
+  
+  main_session <- shiny::MockShinySession$new()
+  map_session <- main_session$makeScope("map-module")
+  table_session <- main_session$makeScope("table-module")
+  table_session2 <- main_session$makeScope("table-module-2")
+  
+  # Track state changes
+  state_changes <- list()
+  callback <- function(selected_id, selected_data, source_id, session) {
+    state_changes <<- append(state_changes, list(list(
+      selected_id = selected_id,
+      source = source_id,
+      timestamp = Sys.time()
+    )))
+  }
+  
+  registry <- create_link_registry(main_session, on_selection_change = callback)
+  
+  test_data <- reactive({
+    data.frame(
+      id = c("STATE_1", "STATE_2", "STATE_3"),
+      name = c("State One", "State Two", "State Three"),
+      latitude = c(40, 41, 42),
+      longitude = c(-100, -101, -102)
+    )
+  })
+  
+  # Register multiple components
+  register_leaflet(map_session, registry, "state_map", test_data, "id")
+  register_dt(table_session, registry, "state_table", test_data, "id")
+  register_dt(table_session2, registry, "state_details", test_data, "id")
+  
+  # Test sequence of selections
+  isolate({
+    registry$set_selection("STATE_1", "state_map")
+    registry$set_selection("STATE_2", "state_table")
+    registry$set_selection("STATE_3", "state_details")
+  })
+  
+  # Check state progression
+  expect_length(state_changes, 3)
+  expect_equal(state_changes[[1]]$selected_id, "STATE_1")
+  expect_equal(state_changes[[2]]$selected_id, "STATE_2")
+  expect_equal(state_changes[[3]]$selected_id, "STATE_3")
+  
+  # Final state should be STATE_3
+  final_selection <- isolate(registry$get_selection())
+  expect_equal(final_selection$selected_id, "STATE_3")
+  expect_equal(final_selection$source, "state_details")
+})

--- a/tests/testthat/test-registry.R
+++ b/tests/testthat/test-registry.R
@@ -1,9 +1,6 @@
 test_that("create_link_registry works", {
   # Mock shiny session
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback  # Add this for cleanup
-  )
+  session <- shiny::MockShinySession$new()
 
   # Create registry
   registry <- create_link_registry(session)
@@ -15,15 +12,13 @@ test_that("create_link_registry works", {
 })
 
 test_that("register_component validates inputs", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
   registry <- create_link_registry(session)
 
   # Test missing component_id
   expect_error(
     registry$register_component(
+      session = session,
       type = "test",
       data_reactive = reactive({
         data.frame(id = 1:3)
@@ -37,6 +32,7 @@ test_that("register_component validates inputs", {
   # Test non-reactive data
   expect_error(
     registry$register_component(
+      session = session,
       component_id = "test",
       type = "test",
       data_reactive = data.frame(id = 1:3), # Not reactive
@@ -47,7 +43,7 @@ test_that("register_component validates inputs", {
 })
 
 test_that("component registration works", {
-  session <- list(input = list())
+  session <- shiny::MockShinySession$new()
   registry <- create_link_registry(session)
 
   # Create mock reactive data
@@ -62,6 +58,7 @@ test_that("component registration works", {
   # Register component (will produce message about unsupported type)
   expect_error(
     registry$register_component(
+      session = session,
       component_id = "test_component",
       type = "test_type",
       data_reactive = test_data,
@@ -73,16 +70,13 @@ test_that("component registration works", {
   # Check component was registered
   components <- registry$get_components()
   expect_length(components, 1)
-  expect_equal(names(components), "test_component")
-  expect_equal(components$test_component$type, "test_type")
-  expect_equal(components$test_component$shared_id_column, "id")
+  expect_equal(names(components), "mock-session-test_component")
+  expect_equal(components[["mock-session-test_component"]]$type, "test_type")
+  expect_equal(components[["mock-session-test_component"]]$shared_id_column, "id")
 })
 
 test_that("component registration works with supported types", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
   registry <- create_link_registry(session)
 
   # Create mock reactive data for DT (supported type)
@@ -97,6 +91,7 @@ test_that("component registration works with supported types", {
   # Register DT component (supported type)
   expect_no_error({
     registry$register_component(
+      session = session,
       component_id = "test_table",
       type = "datatable",
       data_reactive = test_data,
@@ -107,16 +102,13 @@ test_that("component registration works with supported types", {
   # Check component was registered
   components <- registry$get_components()
   expect_length(components, 1)
-  expect_equal(names(components), "test_table")
-  expect_equal(components$test_table$type, "datatable")
-  expect_equal(components$test_table$shared_id_column, "id")
+  expect_equal(names(components), "mock-session-test_table")
+  expect_equal(components[["mock-session-test_table"]]$type, "datatable")
+  expect_equal(components[["mock-session-test_table"]]$shared_id_column, "id")
 })
 
 test_that("leaflet component registration works", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
   registry <- create_link_registry(session)
 
   # Create mock reactive data for leaflet
@@ -132,6 +124,7 @@ test_that("leaflet component registration works", {
   # Register leaflet component (supported type)
   expect_no_error({
     registry$register_component(
+      session = session,
       component_id = "test_map",
       type = "leaflet",
       data_reactive = map_data,
@@ -147,17 +140,14 @@ test_that("leaflet component registration works", {
   # Check component was registered
   components <- registry$get_components()
   expect_length(components, 1)
-  expect_equal(names(components), "test_map")
-  expect_equal(components$test_map$type, "leaflet")
-  expect_equal(components$test_map$shared_id_column, "id")
-  expect_equal(components$test_map$config$lng_col, "longitude")
+  expect_equal(names(components), "mock-session-test_map")
+  expect_equal(components[["mock-session-test_map"]]$type, "leaflet")
+  expect_equal(components[["mock-session-test_map"]]$shared_id_column, "id")
+  expect_equal(components[["mock-session-test_map"]]$config$lng_col, "longitude")
 })
 
 test_that("DT component registration works", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
   registry <- create_link_registry(session)
 
   # Create mock reactive data for DT
@@ -172,6 +162,7 @@ test_that("DT component registration works", {
   # Register DT component (supported type)
   expect_no_error({
     registry$register_component(
+      session = session,
       component_id = "test_table",
       type = "datatable",
       data_reactive = table_data,
@@ -182,16 +173,13 @@ test_that("DT component registration works", {
   # Check component was registered
   components <- registry$get_components()
   expect_length(components, 1)
-  expect_equal(names(components), "test_table")
-  expect_equal(components$test_table$type, "datatable")
-  expect_equal(components$test_table$shared_id_column, "id")
+  expect_equal(names(components), "mock-session-test_table")
+  expect_equal(components[["mock-session-test_table"]]$type, "datatable")
+  expect_equal(components[["mock-session-test_table"]]$shared_id_column, "id")
 })
 
 test_that("registry manages multiple components correctly", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   registry <- create_link_registry(session)
 
@@ -214,20 +202,17 @@ test_that("registry manages multiple components correctly", {
   })
 
   # Register multiple components using the helper functions
-  register_leaflet(registry, "map1", data1, "id")
-  register_dt(registry, "table1", data2, "id")
+  register_leaflet(session, registry, "map1", data1, "id")
+  register_dt(session, registry, "table1", data2, "id")
 
   components <- registry$get_components()
   expect_length(components, 2)
-  expect_true("map1" %in% names(components))
-  expect_true("table1" %in% names(components))
+  expect_true("mock-session-map1" %in% names(components))
+  expect_true("mock-session-table1" %in% names(components))
 })
 
 test_that("selection state management works", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   registry <- create_link_registry(session)
 
@@ -250,16 +235,13 @@ test_that("selection state management works", {
 })
 
 test_that("registry cleanup works", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   registry <- create_link_registry(session)
 
   # Add some components
   data1 <- reactive({ data.frame(id = 1:3, name = c("A", "B", "C")) })
-  register_dt(registry, "table1", data1, "id")
+  register_dt(session, registry, "table1", data1, "id")
 
   # Set selection
   isolate(registry$set_selection("test_id", "test_source"))
@@ -276,17 +258,14 @@ test_that("registry cleanup works", {
 })
 
 test_that("registry handles duplicate component names", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
   
   registry <- create_link_registry(session)
   data1 <- reactive({ data.frame(id = 1:3, name = c("A", "B", "C")) })
   
   # Register same component twice
-  register_dt(registry, "table1", data1, "id")
-  register_dt(registry, "table1", data1, "id")  # Should overwrite
+  register_dt(session, registry, "table1", data1, "id")
+  register_dt(session, registry, "table1", data1, "id")  # Should overwrite
   
   components <- registry$get_components()
   expect_length(components, 1)  # Should only have one

--- a/tests/testthat/test-simple-api.R
+++ b/tests/testthat/test-simple-api.R
@@ -1,5 +1,5 @@
 test_that("link_plots validates inputs", {
-  session <- list(input = list())
+  session <- shiny::MockShinySession$new()
 
   # Test missing session
   expect_error(
@@ -40,7 +40,7 @@ test_that("component type detection works", {
 })
 
 test_that("link_plots creates registry with components", {
-  session <- list(input = list())
+  session <- shiny::MockShinySession$new()
 
   # Create test data
   map_data <- reactive({
@@ -77,15 +77,12 @@ test_that("link_plots creates registry with components", {
   # Check components were registered
   components <- registry$get_components()
   expect_length(components, 2)
-  expect_true("testMap" %in% names(components))
-  expect_true("testTable" %in% names(components))
+  expect_true("mock-session-testMap" %in% names(components))
+  expect_true("mock-session-testTable" %in% names(components))
 })
 
 test_that("link_plots works with 3 components", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   # Create mock reactive data for three components
   data1 <- reactive({
@@ -116,9 +113,9 @@ test_that("link_plots works with 3 components", {
   expect_s3_class(registry, "link_registry")
   components <- registry$get_components()
   expect_length(components, 3)
-  expect_true("table1" %in% names(components))
-  expect_true("table2" %in% names(components))
-  expect_true("table3" %in% names(components))
+  expect_true("mock-session-table1" %in% names(components))
+  expect_true("mock-session-table2" %in% names(components))
+  expect_true("mock-session-table3" %in% names(components))
 
   # Check shared_id_column is consistent
   expect_equal(
@@ -136,10 +133,7 @@ test_that("link_plots works with 3 components", {
 })
 
 test_that("link_plots handles edge cases correctly", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   # Test with single component (should not work)
   single_data <- reactive({
@@ -169,10 +163,7 @@ test_that("link_plots handles edge cases correctly", {
 })
 
 test_that("link_plots validates shared_id_column across all datasets", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   # Data with shared ID column
   good_data <- reactive({
@@ -197,11 +188,7 @@ test_that("link_plots validates shared_id_column across all datasets", {
 })
 
 test_that("link_plots handles different data types in shared column", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
-
+  session <- shiny::MockShinySession$new()
   # Test with character IDs
   char_data <- reactive({
     data.frame(
@@ -252,10 +239,7 @@ test_that("link_plots handles different data types in shared column", {
 })
 
 test_that("link_plots custom handlers are properly stored", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   test_data <- reactive({
     data.frame(
@@ -289,11 +273,11 @@ test_that("link_plots custom handlers are properly stored", {
   components <- registry$get_components()
 
   # Check leaflet handler
-  map_component <- components[["test_map"]]
+  map_component <- components[["mock-session-test_map"]]
   expect_true(is.function(map_component$config$click_handler))
 
   # Check DT handler
-  table_component <- components[["test_table"]]
+  table_component <- components[["mock-session-test_table"]]
   expect_true(is.function(table_component$config$click_handler))
 
   # Check the click behavior
@@ -309,10 +293,7 @@ test_that("link_plots custom handlers are properly stored", {
 })
 
 test_that("link_plots on_selection_change callback works", {
-  session <- list(
-    input = list(),
-    onSessionEnded = function(callback) callback
-  )
+  session <- shiny::MockShinySession$new()
 
   test_data <- reactive({
     data.frame(id = 1:3, name = c("A", "B", "C"))

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -117,6 +117,7 @@ For linking to work, you need:
 
 # Next Steps
 
+- See `vignette("using-with-modules")` for modular applications
 - See `vignette("custom-behaviors")` for advanced customization
 - See `vignette("multiple-components")` for complex linking scenarios
 - See `vignette("troubleshooting")` for common issues and solutions

--- a/vignettes/using-with-modules.Rmd
+++ b/vignettes/using-with-modules.Rmd
@@ -1,0 +1,179 @@
+---
+title: "Using linkeR with Shiny Modules"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Using linkeR with Shiny Modules}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE  # Set to FALSE since these are Shiny examples
+)
+```
+
+```{r setup}
+library(linkeR)
+library(shiny)
+library(leaflet)
+library(DT)
+```
+
+## Introduction: Why a Different Approach for Modules?
+
+While `link_plots()` is perfect for single-file Shiny applications, a more robust pattern is needed when working with **Shiny Modules**. This is because modules are designed to be self-contained and reusable, a principle known as **encapsulation**.
+
+The main app should not need to know the internal `outputId`s of the components within a module. For `linkeR` to work correctly, it needs to be aware of the unique "namespace" that Shiny gives to each module's UI elements.
+
+The recommended pattern for modular apps follows three simple steps that respect module encapsulation and lead to cleaner, more maintainable code.
+
+## The Three-Step Pattern for Modular Linking
+
+The core idea is to create a central "linking manager" (the registry) in your main app and pass it down to each module. The modules then register their own components with this central manager.
+
+1.  **Main App**: Create a central `link_registry` object.
+2.  **Main App**: Pass the `registry` object into each module's server function.
+3.  **Inside Each Module**: Call the relevant `register_xyz` function from the module's server, using the module's own `session` object.
+
+This vignette will walk through building a modular app based on the example found in `inst/examples/modularized_example/`.
+
+---
+
+### Step 1: Create the Map Module (`map_module.R`)
+
+First, we define the UI and server for our map component. The key change is that the server function now accepts a `registry` argument and calls `register_leaflet()` itself.
+
+```{r map-module}
+# /path/to/your/app/map_module.R
+
+#' Map Module UI
+#'
+#' @param id A character string. The namespace ID.
+#' @return A UI definition.
+mapUI <- function(id) {
+  ns <- NS(id)
+  leafletOutput(ns("wastewater_map"), height = "500px")
+}
+
+#' Map Module Server
+#'
+#' @param id A character string. The namespace ID.
+#' @param data A reactive expression returning the data for the map.
+#' @param registry A link_registry object for managing component linking.
+mapServer <- function(id, data, registry) {
+  moduleServer(id, function(input, output, session) {
+
+    # Register this component with the central registry
+    register_leaflet(
+      session = session, # <-- Pass the module's session for namespacing
+      registry = registry,
+      leaflet_output_id = "wastewater_map", # <-- The local ID within this module
+      data_reactive = data,
+      shared_id_column = "id"
+    )
+
+    output$wastewater_map <- renderLeaflet({
+      # ... leaflet rendering logic ...
+    })
+  })
+}
+```
+
+---
+
+### Step 2: Create the Table Module (`table_module.R`)
+
+We do the same thing for our table module. It also accepts the `registry` and registers its own `DT` output.
+
+```{r table-module}
+# /path/to/your/app/table_module.R
+
+#' Table Module UI
+#'
+#' @param id A character string. The namespace ID.
+#' @return A UI definition.
+tableUI <- function(id) {
+  ns <- NS(id)
+  DTOutput(ns("wastewater_table"))
+}
+
+#' Table Module Server
+#'
+#' @param id A character string. The namespace ID.
+#' @param data A reactive expression returning the data for the table.
+#' @param registry A link_registry object for managing component linking.
+tableServer <- function(id, data, registry) {
+  moduleServer(id, function(input, output, session) {
+
+    # Register this component with the central registry
+    register_dt(
+      session = session, # <-- Pass the module's session
+      registry = registry,
+      dt_output_id = "wastewater_table", # <-- The local ID
+      data_reactive = data,
+      shared_id_column = "id"
+    )
+
+    output$wastewater_table <- renderDT({
+      # ... datatable rendering logic ...
+    })
+  })
+}
+```
+
+---
+
+### Step 3: Assemble the Main App (`app.R`)
+
+Finally, the main app ties everything together. Notice how clean the server logic is. It's only responsible for creating the registry and passing it to the modules. It has no knowledge of the internal component IDs (`"wastewater_map"` or `"wastewater_table"`).
+
+```{r main-app}
+# /path/to/your/app/app.R
+
+library(shiny)
+library(leaflet)
+library(DT)
+library(linkeR)
+
+# Source the modules
+source("map_module.R")
+source("table_module.R")
+
+# --- UI ---
+ui <- fluidPage(
+  titlePanel("linkeR Modular Linking Example"),
+  fluidRow(
+    column(7,
+      h4("Wastewater Map (Module 1)"),
+      mapUI("map_module")
+    ),
+    column(5,
+      h4("Facility Data (Module 2)"),
+      tableUI("table_module")
+    )
+  )
+)
+
+# --- Server ---
+server <- function(input, output, session) {
+
+  # --- 1. Create the central link registry ---
+  registry <- create_link_registry(session)
+
+  # Shared reactive data
+  wastewater_data <- reactive({
+    # ... data generation logic ...
+  })
+
+  # --- 2. Pass the registry to each module server ---
+  mapServer("map_module", wastewater_data, registry)
+  tableServer("table_module", wastewater_data, registry)
+}
+
+shinyApp(ui, server)
+```
+
+This pattern ensures that your modules remain self-contained and reusable while allowing `linkeR` to correctly identify and link components across your entire application.


### PR DESCRIPTION
Adds support for shiny apps with modular components and modular namespacing

Since this is a good practice within shiny apps, it is critical that the 1.0 release of linkeR support modularization through sessions.

This is a NON-BREAKING CHANGE for users that are using `link_plots` as this is unchanged. Simply there is now information and methology for using the individual component registration functions and passing in the session context where they are created. This is pretty much only an issue with shiny's namespacing method.

This paradigm (registering components to linkeR from within the component) is pretty reasonable, and gives the users flexibility and control over whether or not specific components are linked within the registry. Additionally, this theoretically allows for multiple registries to be used to create multiple separate links.

@gvegayon @apulsipher I marked you both as reviewers, but I don't think you both necessarily need to review it, just whichever of you has the time first :)

Todo:

- [x] Update example to use `register` functions instead of `link_plots`
- [x] Update `link_plots` documentation to emphasize that it only works in the case of single-file contexts with one session
- [x] Add vignette showcasing modular support
- [x] Update tests for modular support
- [x] Add tests for modular support