### PR TITLE
Update module docs to showcase click_handler

### DIFF
--- a/R/dt.R
+++ b/R/dt.R
@@ -7,7 +7,7 @@
 #' @param dt_output_id Character string: the outputId of your [DT::DTOutput]
 #' @param data_reactive Reactive expression returning the data frame for the table
 #' @param shared_id_column Character string: name of the ID column
-#' @param click_handler Optional function: custom click handler for row selection
+#' @param click_handler Optional function: custom click handler for row selection, must have args (map_proxy, selected_data, session), overrides all default behavior
 #' @returns NULL (invisible). This function is called for its side effects of registering the component.
 #' @export
 #' @examples

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -10,7 +10,7 @@
 #' @param lng_col Character string: name of longitude column (default: "longitude")
 #' @param lat_col Character string: name of latitude column (default: "latitude")
 #' @param highlight_zoom Numeric: zoom level when highlighting (default: 12)
-#' @param click_handler Optional function: custom click handler for row selection
+#' @param click_handler Optional function: custom click handler for row selection, must have args (map_proxy, selected_data, session), overrides all default behavior
 #' @export
 #' @examples
 #' \dontrun{
@@ -75,7 +75,7 @@ register_leaflet <- function(session, registry, leaflet_output_id, data_reactive
       iconColor = "#FFFFFF"
     ),
     original_data_reactive = data_reactive,  # Keep reference to original for custom handlers
-    click_handler = click_handler  # ADD THIS LINE
+    click_handler = click_handler
   )
 
   # Register with the registry using processed data

--- a/inst/examples/modularized_example/map_module.R
+++ b/inst/examples/modularized_example/map_module.R
@@ -22,7 +22,10 @@ mapServer <- function(id, data, registry) {
       registry = registry,
       leaflet_output_id = "wastewater_map", # <-- the local ID
       data_reactive = data,
-      shared_id_column = "id"
+      shared_id_column = "id",
+      click_handler = function(map_proxy, selected_data, session) { # <-- click handler must have map_proxy, selected_data, session, overrides all default behavior
+        print("The leaflet map component was just clicked!")
+      }
     )
 
     output$wastewater_map <- renderLeaflet({

--- a/inst/examples/modularized_example/table_module.R
+++ b/inst/examples/modularized_example/table_module.R
@@ -22,7 +22,10 @@ tableServer <- function(id, data, registry) {
       registry = registry,
       dt_output_id = "wastewater_table", # <-- the local ID
       data_reactive = data,
-      shared_id_column = "id"
+      shared_id_column = "id",
+      click_handler = function(map_proxy, selected_data, session) { # <-- click handler must have map_proxy, selected_data, session, overrides all default behavior
+        print("The DT table component was just clicked!")
+      }
     )
 
     output$wastewater_table <- renderDT({

--- a/man/register_dt.Rd
+++ b/man/register_dt.Rd
@@ -24,7 +24,7 @@ register_dt(
 
 \item{shared_id_column}{Character string: name of the ID column}
 
-\item{click_handler}{Optional function: custom click handler for row selection}
+\item{click_handler}{Optional function: custom click handler for row selection, must have args (map_proxy, selected_data, session), overrides all default behavior}
 }
 \value{
 NULL (invisible). This function is called for its side effects of registering the component.

--- a/man/register_leaflet.Rd
+++ b/man/register_leaflet.Rd
@@ -33,7 +33,7 @@ register_leaflet(
 
 \item{highlight_zoom}{Numeric: zoom level when highlighting (default: 12)}
 
-\item{click_handler}{Optional function: custom click handler for row selection}
+\item{click_handler}{Optional function: custom click handler for row selection, must have args (map_proxy, selected_data, session), overrides all default behavior}
 }
 \description{
 \code{register_leaflet} registers a Leaflet map for linking with other components.

--- a/vignettes/using-with-modules.Rmd
+++ b/vignettes/using-with-modules.Rmd
@@ -72,7 +72,10 @@ mapServer <- function(id, data, registry) {
       registry = registry,
       leaflet_output_id = "wastewater_map", # <-- The local ID within this module
       data_reactive = data,
-      shared_id_column = "id"
+      shared_id_column = "id",
+      click_handler = function(map_proxy, selected_data, session) { # <-- click handler must have map_proxy, selected_data, session, overrides all default behavior
+        print("The leaflet map component was just clicked!")
+      }
     )
 
     output$wastewater_map <- renderLeaflet({
@@ -114,7 +117,10 @@ tableServer <- function(id, data, registry) {
       registry = registry,
       dt_output_id = "wastewater_table", # <-- The local ID
       data_reactive = data,
-      shared_id_column = "id"
+      shared_id_column = "id",
+      click_handler = function(map_proxy, selected_data, session) { # <-- click handler must have map_proxy, selected_data, session, overrides all default behavior
+        print("The DT table component was just clicked!")
+      }
     )
 
     output$wastewater_table <- renderDT({


### PR DESCRIPTION
[ Description generated by Copilot ]

This pull request clarifies and documents the requirements for the `click_handler` argument in both the `register_dt` and `register_leaflet` functions. It updates function documentation, example modules, and vignettes to specify that any custom `click_handler` must accept the arguments `(map_proxy, selected_data, session)` and that providing this handler will override all default click behavior.

Documentation and usage updates:

* Updated the documentation for the `click_handler` parameter in both `register_dt` and `register_leaflet` functions to specify required arguments and override behavior. [[1]](diffhunk://#diff-cbaa8a2c433572b209e098de41a13f7b1918c511e8dee7df0d300ddb83a216dbL10-R10) [[2]](diffhunk://#diff-64d3069bc997443b54be5170488f6bc9a3493a11f3ea321dae6aa085922f8902L13-R13) [[3]](diffhunk://#diff-8228f7fada1c949fe4c364e80ac5c21eac3324cd43ab42ca629c2c1b6c77a2afL27-R27) [[4]](diffhunk://#diff-4e7a050ea7ee4c48b627565fa4df3d558a0add0067960d90c4d8a1593ea3f295L36-R36)
* Updated example module code (`mapServer` and `tableServer` in `inst/examples/modularized_example/`) to demonstrate the correct usage of the `click_handler` with the required arguments. [[1]](diffhunk://#diff-80419ff2fe99bed8965e87bda1736f35860c3cbdd762d971279ee0e602e4c6bcL25-R28) [[2]](diffhunk://#diff-aca4b5b87dc7d6edec8be2d8f57da737eac68218a5876db8381c37169a1dcab1L25-R28)
* Updated vignette examples to show how to use the `click_handler` argument with the proper function signature. [[1]](diffhunk://#diff-d085b0d3b44e878507be619332cf96653ee784211755d75e7a5deff48ab782adL75-R78) [[2]](diffhunk://#diff-d085b0d3b44e878507be619332cf96653ee784211755d75e7a5deff48ab782adL117-R123)

Internal consistency:

* Ensured that the `click_handler` parameter is consistently passed and documented in the internal registration logic for `register_leaflet`.